### PR TITLE
task: WS loading indicators for active graph inquiry operations

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/node.py
+++ b/backend/app/app/api/api_v1/endpoints/node.py
@@ -301,7 +301,6 @@ async def run_user_graph_event(event: dict, send_json: Callable, uuid: UUID) -> 
         if IS_TRANSFORM:
             await nodes_transform(event["node"], send_json, uuid)
 
-
 @router.websocket("/graph/{hid}")
 async def active_graph_inquiry(
     websocket: WebSocket,
@@ -310,15 +309,16 @@ async def active_graph_inquiry(
     db: Session = Depends(deps.get_db)
 ):
     await websocket.accept()
+    await websocket.send_json({"action": "isLoading", "detail": "true" })
     is_project_active = True
     active_inquiry = crud.graphs.get(db, id=hid)
     if active_inquiry is None:
         is_project_active = False
-    else:
-        await websocket.send_json({"action": "refresh"})
+
     while is_project_active:
         try:
             event: dict = await websocket.receive_json()
+            await websocket.send_json({"action": "isLoading", "detail": "true" })
             await run_user_graph_event(
                 event=event,
                 send_json=websocket.send_json,
@@ -332,6 +332,8 @@ async def active_graph_inquiry(
             log.error("Exception inside node.active_project")
             log.error(e)
             is_project_active = False
+        finally:
+            await websocket.send_json({ "action": "isLoading", "detail": "false" })
     await websocket.close()
 
 

--- a/frontend/src/routes/graph-inquiry/index.tsx
+++ b/frontend/src/routes/graph-inquiry/index.tsx
@@ -54,6 +54,8 @@ const getEdgeId = () => {
   return `e-tmp-${edgeId}`
 }
 
+const loadingToastId = "loadingToast";
+
 export default function GraphInquiry({ }: GraphInquiryProps) {
   const dispatch = useAppDispatch();
   const { hid } = useParams()
@@ -198,8 +200,10 @@ export default function GraphInquiry({ }: GraphInquiryProps) {
           toast.info('No results found');
         }
       }
-      if (lastJsonMessage.action === 'refresh') {
-        toast.info(`Loading plugins...`);
+
+      if (lastJsonMessage.action === 'isLoading') {
+        lastJsonMessage.detail === 'true' ? toast.loading("Loading...", { closeButton: true, isLoading: true, toastId: loadingToastId })
+          : toast.update(loadingToastId, { render: "Success", type: "success", isLoading: false, autoClose: 1000 });
       }
     }
   }, [lastJsonMessage, setMessageHistory]);


### PR DESCRIPTION
## Summary
- Basic loading toasts for any WS graph inquiry operation against the `/node/graph/:hid` endpoint
- Removed the `refresh`  WS action in favor of using the new `isLoading` action for the initial project plugin load too

## Testing Instructions
- Select a graph and try running transforms / edits / deletes / updates
- A loading indicator followed by a success message should display appropriately