### PR TITLE
[Bug] Cleanup routine for volumes is presumably too greedy

### DIFF
--- a/ob/cmd/cleanup
+++ b/ob/cmd/cleanup
@@ -3,8 +3,7 @@
 
 run_cleanup() {
     heading "Stopping containers and removing volumes"
-    ob_compose down
-    $docker_path volume rm $($docker_path volume ls -q) # &> /dev/null
+    ob_compose down --volumes
     success "Finished cleanup."
     exit 0
 }


### PR DESCRIPTION
## Description

I today observed a likely unwanted behavior when I spun up OSINTBuddy. I struggled with deploying OSINTBuddy to a different host. After some configuring, I decided that it would be good to have a clean start again and found the cleanup command:

> `cleanup: Remove docker volumes.`

To my dismay, I found that the call listed a large number of volumes from other deployments as well.

## Setup to reproduce

- Fresh pull of OSINTBuddy, not running, no Docker volumes at all
- Create a standalone volume not related to OSINTBuddy
- Invoke cleanup command
- Docker engine version:    26.1.1
- Docker compose version:  2.27.0

__Caution: Reproducing may remove more Docker volumes than intended.__

## Expectation

- Nothing happens / no tampering with other Docker resources not related to OSINTBuddy

## Execution

```shell
~/osintbuddy$ docker volume create test

~/osintbuddy$ ./launcher cleanup
WARN[0000] /srv/osintbuddy/ob/alpha-compose.yml: `version` is obsolete
[OSINTBuddy: cleanup] Stopping containers and removing volumes
WARN[0000] /srv/osintbuddy/ob/alpha-compose.yml: `version` is obsolete
test
[OSINTBuddy: cleanup] Finished cleanup.

```

## Observation

Gone are all the docker volumes on the host.

```shell
~/osintbuddy$ docker volume ls
DRIVER    VOLUME NAME
```

## Cause and Fix

The removal of the volumes is using a dangerously global scope in the [`run_cleanup` procedure](https://github.com/jerlendds/osintbuddy/blob/622fc581f947c59b9f8bd10676185b3ee29a5db9/ob/cmd/cleanup#L7):

```shell
ob_compose down
$docker_path volume rm $($docker_path volume ls -q) # &> /dev/null
```

Instead of interfacing Docker volume command directly, I suggest using the compose command in conjunction with `--volumes` instead:

```shell
ob_compose down --volumes
```

## Test

```shell
~/osintbuddy$ docker volume create test
test

~/osintbuddy$ ./launcher start
WARN[0000] /srv/osintbuddy/ob/alpha-compose.yml: `version` is obsolete
[+] Running 13/13
 ✔ Network ob_default        Created                                                                                                                  0.1s
 ✔ Volume "ob_ob-db-data"    Created                                                                                                                  0.0s
 ✔ Volume "ob_ob-solr-data"  Created                                                                                                                  0.0s
 ✔ Volume "ob_ob-sdb-data"   Created                                                                                                                  0.0s
 ✔ Container ob_dev_sdb      Started                                                                                                                  3.2s
 ✔ Container ob_dev_janus    Started                                                                                                                  2.5s
 ✔ Container ob_dev_redis    Started                                                                                                                  2.5s
 ✔ Container ob_dev_ui       Started                                                                                                                  2.3s
 ✔ Container ob_dev_db       Started                                                                                                                  2.4s
 ✔ Container ob_dev_index    Started                                                                                                                  2.5s
 ✔ Container ob_dev_s3       Started                                                                                                                  3.2s
 ✔ Container ob_dev_backend  Started                                                                                                                  3.7s
 ✔ Container ob_dev_casdoor  Started                                                                                                                  5.6s
[OSINTBuddy: start] Starting OSINTBuddy...
[OSINTBuddy: start] After JanusGraph connects to ScyllaDB and Solr, the app is ready for use.
[OSINTBuddy: start] Please allow a few minutes for JanusGraph to finish starting up.

[OSINTBuddy: start] To monitor when JanusGraph is ready, run: ./launcher logs janus
[OSINTBuddy: start] Once ready you can access OSINTBuddy through the following URLs:
[OSINTBuddy: start]       http://localhost:3000        - frontend
[OSINTBuddy: start]       http://localhost:45910       - casdoor
[OSINTBuddy: start]       http://localhost:48997/docs  - docs
[OSINTBuddy: start]       http://localhost:48997/api   - backend

~/osintbuddy$ ./launcher cleanup
WARN[0000] /srv/osintbuddy/ob/alpha-compose.yml: `version` is obsolete
[+] Stopping 9/9
 ✔ Container ob_dev_s3       Stopped                                                                                                                  0.0s
 ✔ Container ob_dev_sdb      Stopped                                                                                                                  5.0s
 ✔ Container ob_dev_index    Stopped                                                                                                                  1.4s
 ✔ Container ob_dev_redis    Stopped                                                                                                                  1.1s
 ✔ Container ob_dev_ui       Stopped                                                                                                                  1.6s
 ✔ Container ob_dev_casdoor  Stopped                                                                                                                  1.2s
 ✔ Container ob_dev_janus    Stopped                                                                                                                 10.8s
 ✔ Container ob_dev_backend  Stopped                                                                                                                  2.4s
 ✔ Container ob_dev_db       Stopped                                                                                                                  0.6s
[OSINTBuddy: cleanup] Stopping containers and removing volumes
WARN[0000] /srv/osintbuddy/ob/alpha-compose.yml: `version` is obsolete
[+] Running 13/13
 ✔ Container ob_dev_redis    Removed                                                                                                                  0.1s
 ✔ Container ob_dev_casdoor  Removed                                                                                                                  0.0s
 ✔ Container ob_dev_s3       Removed                                                                                                                  0.1s
 ✔ Container ob_dev_janus    Removed                                                                                                                  0.0s
 ✔ Container ob_dev_index    Removed                                                                                                                  0.0s
 ✔ Container ob_dev_sdb      Removed                                                                                                                  0.1s
 ✔ Container ob_dev_ui       Removed                                                                                                                  0.1s
 ✔ Container ob_dev_backend  Removed                                                                                                                  0.0s
 ✔ Container ob_dev_db       Removed                                                                                                                  0.0s
 ✔ Volume ob_ob-db-data      Removed                                                                                                                  0.1s
 ✔ Volume ob_ob-sdb-data     Removed                                                                                                                  0.0s
 ✔ Volume ob_ob-solr-data    Removed                                                                                                                  0.0s
 ✔ Network ob_default        Removed                                                                                                                  0.2s
[OSINTBuddy: cleanup] Finished cleanup.

~/osintbuddy$ docker volume ls
DRIVER    VOLUME NAME
local     test
```

## Disclaimer

I wrote that it was probably undesirable behavior, even though _it did pretty much what the command description stated_. If this is really what you want, you should at least change the description so that all volumes are deleted, regardless of whether they belong to OSINTBuddy or not. Otherwise, more could be caught off guard.
